### PR TITLE
add vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ docker run -v /path/to/config.yaml:/opt/sinopia/config.yaml --name sinopia -d -p
 
 Restart the container anytime you change the config.
 
+### configure Vagrant
+ 
+Setting the npm registry to `http://localhost:4873` in a Dockerfile which should point to the sinopia registry locally will not work during the `docker build` process, since localhost:4873 references to the Docker container itself and not the host-machine where sinopia runs.
+With the Vagrant configuration one could locally spin up this Dockerfile in a vbox with the command `vagrant up` and reference this registry it in a 'target'-Dockerfile with `RUN npm set registry http://10.10.10.10:4873`.
+ 
+```
+# vagrant up
+```
+
+and in the Dockerfile of your application set
+
+```
+CMD npm set registry http://10.10.10.10:4873
+```
+
+[Vagrant](https://en.wikipedia.org/wiki/Vagrant_\(software\)) is open source. See install instructions for [mac](http://sourabhbajaj.com/mac-setup/Vagrant/README.html) or [\*nix](http://www.olindata.com/blog/2014/07/installing-vagrant-and-virtual-box-ubuntu-1404-lts). 
+
 ### Backups
 
 `docker run --volumes-from sinopia -v $(pwd):/backup ubuntu tar cvf /backup/backup.tar /opt/sinopia`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--memory", "2048"]
+    v.customize ["modifyvm", :id, "--cpus", "2"]
+  end
+
+  config.vm.provision "docker" do |docker|
+    docker.pull_images "keyvanfatehi/sinopia:latest"
+    docker.run "keyvanfatehi/sinopia", args: "-p 4873:4873"
+  end
+
+  config.vm.network "private_network", ip: "10.10.10.10"
+end


### PR DESCRIPTION
Setting the npm registry to `http://localhost:4873` in a Dockerfile which should point to the sinopia registry locally will not work during the `docker build` process, since localhost:4873 references to the Docker container itself and not the host-machine where sinopia runs.
With the Vagrant configuration one could locally spin up this Dockerfile in a vbox with the command `vagrant up` and reference this registry it in a 'target'-Dockerfile with `RUN npm set registry http://10.10.10.10:4873`.

```
# vagrant up
```

and in the Dockerfile of your application set

```
CMD npm set registry http://10.10.10.10:4873
```
